### PR TITLE
Histogram Expiry Detector

### DIFF
--- a/alert/expiring.py
+++ b/alert/expiring.py
@@ -1,0 +1,80 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Search for regression in a histogram dump directory produced by the
+# node exporter.
+
+import json
+import urllib2
+from datetime import datetime, timedelta
+
+from bs4 import BeautifulSoup
+from mail import send_ses
+
+HISTOGRAMS_FILE = "Histograms.json"
+EMAIL_TIME_BEFORE = timedelta(weeks=1)
+FROM_ADDR = "cerberus-alert@mozilla.com"
+
+def get_future_release_dates():
+    # scrape for future release date tables
+    response = json.loads(urllib2.urlopen("https://wiki.mozilla.org/api.php?action=parse&format=json&page=RapidRelease/Calendar").read())
+    soup = BeautifulSoup(response["parse"]["text"]["*"])
+    table = soup.find(id="Future_branch_dates").find_parent("h2").find_next_sibling("table")
+    result = {}
+    for i, row in enumerate(table.find_all("tr")):
+        if i == 0: continue # skip the header row
+        version = list(row.find_all("td"))[-1].string.strip().replace("Firefox ", "")
+        version = version.split(".")[0] # only keep the major version
+        date_string = list(row.find_all("th"))[-1].string.strip(" \t\r\n*")
+        try: result[version] = datetime.strptime(date_string, "%Y-%m-%d")
+        except ValueError: pass
+    return result
+
+def is_expiring(histogram_entry, now, release_dates):
+    expiry = histogram_entry.get("expires_in_version", "never").split(".")[0]
+
+    # check if the version is unknown or far into the future
+    if expiry in {"never", "default"}: return False
+    try:
+        max_release = max(map(int, release_dates.keys()))
+        if int(expiry) > max_release: return False
+    except ValueError: pass
+    if expiry not in release_dates: return True
+    
+    # known version, check if it is close to release
+    return release_dates[expiry] - now < EMAIL_TIME_BEFORE
+
+def main():
+    with open(HISTOGRAMS_FILE) as f: histograms = json.load(f)
+    now, release_dates = datetime.now(), get_future_release_dates()
+    notifiable_histograms = sorted([h for h in histograms.items() if is_expiring(h[1], now, release_dates)], key=lambda h: h[0])
+    
+    # organize histograms into buckets indexed by email
+    email_histogram_names = {}
+    for name, entry in notifiable_histograms:
+        if entry.get("alert_emails", False):
+            for email in entry["alert_emails"]:
+                if email not in email_histogram_names: email_histogram_names[email] = []
+                email_histogram_names[email].append(name)
+    
+    # send out emails detailing the histograms that they are subscribed to that are expiring
+    for email, expiring_histogram_names in email_histogram_names.items():
+        email_body = """\
+The following histograms will be expired on or before {}, and should be removed from the codebase:
+
+{}
+
+This is an automated message sent by Cerberus. See https://github.com/mozilla/cerberus for details and source code.
+        """.format(
+            (now + EMAIL_TIME_BEFORE).date(),
+            "\n".join("* {}{} expires in version {}".format(
+                "[SUBSCRIBED] " if name in expiring_histogram_names else "",
+                name, entry["expires_in_version"])
+                for name, entry in notifiable_histograms)
+        )
+        print("Sending email to {} with body:\n\n{}\n\n".format(email, email_body))
+        send_ses(FROM_ADDR, "Telemetry Histogram Expiry", email_body, email)
+
+if __name__ == "__main__":
+    main()

--- a/alert/expiring.py
+++ b/alert/expiring.py
@@ -6,6 +6,8 @@
 # node exporter.
 
 import json
+import os
+import sys
 import urllib2
 from datetime import datetime, timedelta
 
@@ -13,12 +15,27 @@ from bs4 import BeautifulSoup
 from mail import send_ses
 from version_compare import version_compare
 
-NOTIFICATIONS_FILE = "already_notified_histograms.json"
-HISTOGRAMS_FILE = "Histograms.json"
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+NOTIFICATIONS_FILE = os.path.join(SCRIPT_DIR, "already_notified_histograms.json")
+HISTOGRAMS_FILE = os.path.join(SCRIPT_DIR, "Histograms.json")
 EMAIL_TIME_BEFORE = timedelta(weeks=1)
 FROM_ADDR = "telemetry-alert@mozilla.com"
 
 def get_future_release_dates():
+    """Obtain a dictionary mapping future Firefox version numbers to their intended release date.
+
+Takes data from the RapidRelease page of the Mozilla Wiki. The page is expected to be in the following form:
+
+    (...beginning of document...)
+    <h2><span id="Future_branch_dates">(TITLE)</span></h2>
+    (...anything other than a table...)
+    <table>
+      (header row)
+      <tr>(...) <th>(expected release date as YYYY-MM-DD)</th> <td>Firefox (Firefox version)</td> </tr>
+      (...other rows...)
+    </table>
+    (...rest of document...)"""
     # scrape for future release date tables
     response = json.loads(urllib2.urlopen("https://wiki.mozilla.org/api.php?action=parse&format=json&page=RapidRelease/Calendar").read())
     soup = BeautifulSoup(response["parse"]["text"]["*"])
@@ -39,7 +56,7 @@ def is_expiring(histogram_entry, now, release_dates):
     if expiry in {"never", "default"}: return False
 
     # check if the expiration version has a known release date
-    if expiry in release_dates: return release_dates[expiry] - now < EMAIL_TIME_BEFORE
+    if expiry in release_dates: return release_dates[expiry] - now <= EMAIL_TIME_BEFORE
 
     # find the very next release in which the histogram is known to be expiring
     releases = sorted(release_dates.iteritems(), cmp=lambda x, y: version_compare(x[0], y[0]))
@@ -47,28 +64,21 @@ def is_expiring(histogram_entry, now, release_dates):
         return False
     for version, release_date in releases:
         if version_compare(expiry, version) <= 0:
-            return release_date - now < EMAIL_TIME_BEFORE
+            return release_date - now <= EMAIL_TIME_BEFORE
     return False # version expires in an unknown future version
 
-def main():
+def email_histogram_subscribers(now, notifiable_histograms):
     # load the histograms that we already emailed expiration notices for
     try:
-        with open(NOTIFICATIONS_FILE, "r") as f: already_notified_histograms = json.load(f)
+        with open(NOTIFICATIONS_FILE, "r") as f: already_notified_histograms = set(json.load(f))
     except (IOError, ValueError):
-        already_notified_histograms = []
-
-    # get a list of histograms that are expiring and net yet notified about, sorted alphabetically
-    with open(HISTOGRAMS_FILE) as f: histograms = json.load(f)
-    now, release_dates = datetime.now(), get_future_release_dates()
-    notifiable_histograms = sorted([h for h in histograms.items() if
-        is_expiring(h[1], now, release_dates) and h[0] not in already_notified_histograms],
-        key=lambda h: h[0])
+        already_notified_histograms = set()
 
     # organize histograms into buckets indexed by email
     email_histogram_names = {}
     for name, entry in notifiable_histograms:
-        if entry.get("alert_emails", False):
-            for email in entry["alert_emails"]:
+        if name not in already_notified_histograms:
+            for email in entry.get("alert_emails", []):
                 if email not in email_histogram_names: email_histogram_names[email] = []
                 email_histogram_names[email].append(name)
 
@@ -91,8 +101,72 @@ This is an automated message sent by Cerberus. See https://github.com/mozilla/ce
         send_ses(FROM_ADDR, "Telemetry Histogram Expiry", email_body, email)
 
     # save the newly notified histograms
-    already_notified_histograms += [name for name, entry in notifiable_histograms]
-    with open(NOTIFICATIONS_FILE, "w") as f: json.dump(already_notified_histograms, f, indent=2)
+    already_notified_histograms.update(name for name, entry in notifiable_histograms)
+    with open(NOTIFICATIONS_FILE, "w") as f: json.dump(list(already_notified_histograms), f, indent=2)
+
+def get_expiring_histograms(now, release_dates, histograms):
+    return sorted([
+        (name, entry) for name, entry in histograms.items() if is_expiring(entry, now, release_dates)
+    ], key=lambda h: h[0])
+
+def run_tests():
+    release_dates1 = {
+      "38": datetime(2015, 6, 2),
+      "39": datetime(2015, 6, 30),
+      "40": datetime(2015, 8, 11),
+      "41": datetime(2015, 9, 22),
+      "42": datetime(2015, 11, 3),
+      "43": datetime(2015, 12, 15),
+      "44": datetime(2016, 1, 26),
+      "45": datetime(2016, 3, 8),
+      "46": datetime(2016, 4, 19),
+      "47": datetime(2016, 5, 31),
+    }
+    release_dates2 = {
+      "41": datetime(2015, 9, 22),
+      "42": datetime(2015, 11, 3),
+      "43": datetime(2015, 12, 15),
+    }
+    histograms = {
+        "a": {"expires_in_version": "40"},
+        "b": {"expires_in_version": "40"},
+        "c": {"expires_in_version": "40.5"},
+        "d": {"expires_in_version": "50"},
+        "e": {"expires_in_version": "50"},
+        "f": {"expires_in_version": "41"},
+        "g": {"expires_in_version": "45"},
+        "h": {"expires_in_version": "50a4"},
+    }
+    assert get_expiring_histograms(datetime(2015, 8, 3), release_dates1, histograms) == []
+    assert get_expiring_histograms(datetime(2015, 8, 4), release_dates1, histograms) == [("a", {"expires_in_version": "40"}), ("b", {"expires_in_version": "40"})]
+    assert get_expiring_histograms(datetime(2015, 9, 1), release_dates2, histograms) == []
+    assert get_expiring_histograms(datetime(2015, 12, 20), release_dates2, histograms) == [("f", {"expires_in_version": "41"})]
+
+    print "All tests passed!"
+    sys.exit()
+
+def main():
+    if len(sys.argv) != 2 or sys.argv[1] not in {"list", "email", "test"}:
+        print "Usage: {} list|email|test".format(sys.argv[0])
+        print "  {} list    list histograms that are soon expiring".format(sys.argv[0])
+        print "  {} email   notify users of histograms that are soon expiring".format(sys.argv[0])
+        print "  {} test    run various internal tests".format(sys.argv[0])
+        sys.exit(1)
+    if sys.argv[1] == "test": run_tests()
+
+    # get a list of histograms that are expiring and net yet notified about, sorted alphabetically
+    with open(HISTOGRAMS_FILE) as f: histograms = json.load(f)
+    now, release_dates = datetime.now(), get_future_release_dates()
+    now = datetime(2015, 8, 5)
+    notifiable_histograms = get_expiring_histograms(now, release_dates, histograms)
+    if sys.argv[1] == "list":
+        for name, entry in notifiable_histograms:
+            print("{} expires in version {}{}".format(
+                name, entry["expires_in_version"],
+                " (watched by {})".format(", ".join(email for email in entry["alert_emails"])) if "alert_emails" in entry else ""
+            ))
+    else: # send out emails
+        email_histogram_subscribers(now, notifiable_histograms)
 
 if __name__ == "__main__":
     main()

--- a/alert/mail.py
+++ b/alert/mail.py
@@ -2,18 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import boto.ses
+import boto
 
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-import json
-
-with open("aws-settings.json", "r") as f:
-  settings = json.load(f)
-  AWS_ACCESS_KEY = settings["AWS_ACCESS_KEY"]
-  AWS_SECRET_ACCESS_KEY = settings["AWS_SECRET_ACCESS_KEY"]
-  AWS_REGION = settings["AWS_REGION"]
 
 def send_ses(fromaddr,
              subject,
@@ -21,13 +14,6 @@ def send_ses(fromaddr,
              recipient,
              filename=''):
     """Send an email via the Amazon SES service.
-
-Configuration is stored in `aws-settings.json` in the working directory, of the following form:
-  {
-    "AWS_ACCESS_KEY": "ACESS_KEY_GOES_HERE",
-    "AWS_SECRET_ACCESS_KEY": "SECRET_ACCESS_KEY_GOES_HERE",
-    "AWS_REGION": "us-west-2"
-  }
 
 Example:
   send_ses('me@example.com, 'greetings', "Hi!", 'you@example.com)
@@ -47,7 +33,7 @@ Return:
         part.add_header('Content-Disposition', 'attachment', filename=filename)
         msg.attach(part)
 
-    conn = boto.ses.connect_to_region(AWS_REGION, aws_access_key_id=AWS_ACCESS_KEY, aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
+    conn = boto.connect_ses()
     result = conn.send_raw_email(msg.as_string())
 
     return result if 'ErrorResponse' in result else ''

--- a/alert/mail.py
+++ b/alert/mail.py
@@ -22,20 +22,19 @@ def send_ses(fromaddr,
              filename=''):
     """Send an email via the Amazon SES service.
 
-    Configuration is stored in `aws-settings.json` in the working directory, of the following form:
-      {
-        "AWS_ACCESS_KEY": "ACESS_KEY_GOES_HERE",
-        "AWS_SECRET_ACCESS_KEY": "SECRET_ACCESS_KEY_GOES_HERE",
-        "AWS_REGION": "us-west-2"
-      }
+Configuration is stored in `aws-settings.json` in the working directory, of the following form:
+  {
+    "AWS_ACCESS_KEY": "ACESS_KEY_GOES_HERE",
+    "AWS_SECRET_ACCESS_KEY": "SECRET_ACCESS_KEY_GOES_HERE",
+    "AWS_REGION": "us-west-2"
+  }
 
-    Example:
-      send_ses('me@example.com, 'greetings', "Hi!", 'you@example.com)
+Example:
+  send_ses('me@example.com, 'greetings', "Hi!", 'you@example.com)
 
-    Return:
-      If 'ErrorResponse' appears in the return message from SES,
-      return the message, otherwise return an empty '' string.
-    """
+Return:
+  If 'ErrorResponse' appears in the return message from SES,
+  return the message, otherwise return an empty '' string."""
     msg = MIMEMultipart()
     msg['Subject'] = subject
     msg['From'] = fromaddr

--- a/alert/mail.py
+++ b/alert/mail.py
@@ -2,11 +2,18 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import boto
+import boto.ses
 
 from email.mime.application import MIMEApplication
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+import json
+
+with open("aws-settings.json", "r") as f:
+  settings = json.load(f)
+  AWS_ACCESS_KEY = settings["AWS_ACCESS_KEY"]
+  AWS_SECRET_ACCESS_KEY = settings["AWS_SECRET_ACCESS_KEY"]
+  AWS_REGION = settings["AWS_REGION"]
 
 def send_ses(fromaddr,
              subject,
@@ -14,6 +21,13 @@ def send_ses(fromaddr,
              recipient,
              filename=''):
     """Send an email via the Amazon SES service.
+
+    Configuration is stored in `aws-settings.json` in the working directory, of the following form:
+      {
+        "AWS_ACCESS_KEY": "ACESS_KEY_GOES_HERE",
+        "AWS_SECRET_ACCESS_KEY": "SECRET_ACCESS_KEY_GOES_HERE",
+        "AWS_REGION": "us-west-2"
+      }
 
     Example:
       send_ses('me@example.com, 'greetings', "Hi!", 'you@example.com)
@@ -34,7 +48,7 @@ def send_ses(fromaddr,
         part.add_header('Content-Disposition', 'attachment', filename=filename)
         msg.attach(part)
 
-    conn = boto.connect_ses()
+    conn = boto.ses.connect_to_region(AWS_REGION, aws_access_key_id=AWS_ACCESS_KEY, aws_secret_access_key=AWS_SECRET_ACCESS_KEY)
     result = conn.send_raw_email(msg.as_string())
 
     return result if 'ErrorResponse' in result else ''

--- a/alert/version_compare.py
+++ b/alert/version_compare.py
@@ -1,0 +1,53 @@
+import re
+
+def parse_part(part):
+    if part is None or part == "": return (0, None, 0, None)
+    if part == "*": return (float("inf"),)
+    match = re.match("(-?\d+)(?:(\D+)(?:(-?\d+)(?:(\D+))?)?)?", part)
+    components = list(match.groups())
+    components[2] = int(components[2]) if components[2] is not None else 0
+    if components[1] == "+":
+        return (int(components[0]) + 1, "pre", components[2], components[3])
+    return (int(components[0]), components[1], components[2], components[3])
+
+def part_compare(part1, part2):
+    for component1, component2 in zip(parse_part(part1), parse_part(part2)):
+        if component1 is not None and component2 is None: return -1
+        if component1 is None and component2 is not None: return 1
+        if component1 < component2: return -1
+        if component1 > component2: return 1
+    return 0
+
+def version_compare(version1, version2):
+    for result in map(part_compare, version1.strip().split("."), version2.strip().split(".")):
+        if result != 0: return result
+    return 0
+
+if __name__ == "__main__":
+    assert version_compare("1.-1", "1") == -1
+    assert version_compare("1", "1.") == 0
+    assert version_compare("1.", "1.0") == 0
+    assert version_compare("1.0", "1.0.0") == 0
+    assert version_compare("1.0.0", "1.1a") == -1
+    assert version_compare("1.1a", "1.1aa") == -1
+    assert version_compare("1.1aa", "1.1ab") == -1
+    assert version_compare("1.1ab", "1.1b") == -1
+    assert version_compare("1.1b", "1.1c") == -1
+    assert version_compare("1.1c", "1.1pre") == -1
+    assert version_compare("1.1pre", "1.1pre0") == 0
+    assert version_compare("1.1pre0", "1.0+") == 0
+    assert version_compare("1.0+", "1.1pre1a") == -1
+    assert version_compare("1.1pre1a", "1.1pre1aa") == -1
+    assert version_compare("1.1pre1aa", "1.1pre1b") == -1
+    assert version_compare("1.1pre1b", "1.1pre1") == -1
+    assert version_compare("1.1pre1", "1.1pre2") == -1
+    assert version_compare("1.1pre2", "1.1pre10") == -1
+    assert version_compare("1.1pre10", "1.1.-1") == -1
+    assert version_compare("1.1.-1", "1.1") == -1
+    assert version_compare("1.1", "1.1.0") == 0
+    assert version_compare("1.1.0", "1.1.00") == 0
+    assert version_compare("1.1.00", "1.10") == -1
+    assert version_compare("1.10", "1.*") == -1
+    assert version_compare("1.*", "1.*.1") == -1
+    assert version_compare("1.*.1", "2.0") == -1
+    print "All tests passed!"

--- a/run.sh
+++ b/run.sh
@@ -13,6 +13,7 @@ rm -rf ./histograms &&
 wget https://raw.githubusercontent.com/mozilla/gecko-dev/master/toolkit/components/telemetry/Histograms.json -O Histograms.json &&
 nodejs exporter/export.js &&
 python alert/alert.py &&
-python alert/post.py
+python alert/post.py &&
+python alert/expiring.py
 
 popd

--- a/run.sh
+++ b/run.sh
@@ -14,6 +14,6 @@ wget https://raw.githubusercontent.com/mozilla/gecko-dev/master/toolkit/componen
 nodejs exporter/export.js &&
 python alert/alert.py &&
 python alert/post.py &&
-python alert/expiring.py
+python alert/expiring.py email
 
 popd


### PR DESCRIPTION
Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1149741

Email alerts are sent out listing every histogram that is expired or is soon to be expired. Running it at the moment will result in something like the following:

```
Sending email to rvitillo@mozilla.com with body:
The following histograms will be expired on or before 2015-05-27, and should be removed from the codebase:

* [SUBSCRIBED] BLOCKLIST_SYNC_FILE_LOAD expires in version 35
* NEWTAB_PAGE_SHOWN expires in version 35
* NEWTAB_PAGE_SITE_CLICKED expires in version 35
* TELEMETRY_TEST_EXPIRED expires in version 4.0a1

This is an automated message sent by Cerberus. See https://github.com/mozilla/cerberus for details and source code.
```
