### PR TITLE
Be more explicit about the expiry version if not specified

### DIFF
--- a/alert/expiring.py
+++ b/alert/expiring.py
@@ -90,7 +90,7 @@ The following histograms will be expiring on {}, and should be removed from the 
 This is an automated message sent by Cerberus. See https://github.com/mozilla/cerberus for details and source code.""".format(
             now + EMAIL_TIME_BEFORE,
             "\n".join("* {} expires in version {} ({}) - {}".format(
-                name, entry["expires_in_version"],
+                name, version_normalize_nightly(entry["expires_in_version"]),
                 "watched by {}".format(", ".join(email for email in entry["alert_emails"])) if "alert_emails" in entry else "no watchers",
                 entry["description"]
             ) for name, entry in notifiable_histograms if name in expiring_histogram_names)


### PR DESCRIPTION
    $ python expiring.py preview 2015-08-03
    Email notification for dev-telemetry-alerts@lists.mozilla.org:
    ===============================================
    The following histograms will be expiring on 2015-08-10, and should be removed from the codebase, or have its expiry date updated:

    * LOOP_SHARING_STATE_CHANGE_1 expires in version 43.0a1 (watched by firefox-dev@mozilla.org, mdeboer@mozilla.com) - Number of times the sharing feature has been enabled and disabled (0=WINDOW_ENABLED, 1=WINDOW_DISABLED, 2=BROWSER_ENABLED, 3=BROWSER_DISABLED)
    * LOOP_TWO_WAY_MEDIA_CONN_LENGTH_1 expires in version 43.0a1 (watched by firefox-dev@mozilla.org, dmose@mozilla.com) - Connection length for bi-directionally connected media (0=SHORTER_THAN_10S, 1=BETWEEN_10S_AND_30S, 2=BETWEEN_30S_AND_5M, 3=MORE_THAN_5M)

    This is an automated message sent by Cerberus. See https://github.com/mozilla/cerberus for details and source code.
    ===============================================

    Email notification for dmose@mozilla.com:
    ===============================================
    The following histograms will be expiring on 2015-08-10, and should be removed from the codebase, or have its expiry date updated:

    * LOOP_TWO_WAY_MEDIA_CONN_LENGTH_1 expires in version 43.0a1 (watched by firefox-dev@mozilla.org, dmose@mozilla.com) - Connection length for bi-directionally connected media (0=SHORTER_THAN_10S, 1=BETWEEN_10S_AND_30S, 2=BETWEEN_30S_AND_5M, 3=MORE_THAN_5M)

    This is an automated message sent by Cerberus. See https://github.com/mozilla/cerberus for details and source code.
    ===============================================

    Email notification for mdeboer@mozilla.com:
    ===============================================
    The following histograms will be expiring on 2015-08-10, and should be removed from the codebase, or have its expiry date updated:

    * LOOP_SHARING_STATE_CHANGE_1 expires in version 43.0a1 (watched by firefox-dev@mozilla.org, mdeboer@mozilla.com) - Number of times the sharing feature has been enabled and disabled (0=WINDOW_ENABLED, 1=WINDOW_DISABLED, 2=BROWSER_ENABLED, 3=BROWSER_DISABLED)

    This is an automated message sent by Cerberus. See https://github.com/mozilla/cerberus for details and source code.
    ===============================================

    Email notification for firefox-dev@mozilla.org:
    ===============================================
    The following histograms will be expiring on 2015-08-10, and should be removed from the codebase, or have its expiry date updated:

    * LOOP_SHARING_STATE_CHANGE_1 expires in version 43.0a1 (watched by firefox-dev@mozilla.org, mdeboer@mozilla.com) - Number of times the sharing feature has been enabled and disabled (0=WINDOW_ENABLED, 1=WINDOW_DISABLED, 2=BROWSER_ENABLED, 3=BROWSER_DISABLED)
    * LOOP_TWO_WAY_MEDIA_CONN_LENGTH_1 expires in version 43.0a1 (watched by firefox-dev@mozilla.org, dmose@mozilla.com) - Connection length for bi-directionally connected media (0=SHORTER_THAN_10S, 1=BETWEEN_10S_AND_30S, 2=BETWEEN_30S_AND_5M, 3=MORE_THAN_5M)

    This is an automated message sent by Cerberus. See https://github.com/mozilla/cerberus for details and source code.
    ===============================================
