### PR TITLE
Notify mailing list of already expired histograms

### DIFF
--- a/alert/expiring.py
+++ b/alert/expiring.py
@@ -19,7 +19,7 @@ EMAIL_TIME_BEFORE       = timedelta(weeks=1) # release future date offset
 FROM_ADDR               = "telemetry-alert@mozilla.com" # email address to send alerts from
 GENERAL_TELEMETRY_ALERT = "dev-telemetry-alerts@lists.mozilla.org" # email address that will receive all notifications
 
-def get_future_release_dates():
+def get_release_dates():
     """Obtain a dictionary mapping future Firefox version numbers to their intended release date.
 
 Takes data from the RapidRelease page of the Mozilla Wiki. The page is expected to be in the following form:
@@ -30,7 +30,23 @@ Takes data from the RapidRelease page of the Mozilla Wiki. The page is expected 
     <table>
       (header row)
       <tr>
-        (..other columns...)
+        (..other td columns...)
+        <th>(expected merge date as YYYY-MM-DD)</th>
+        <td>Firefox (Firefox nightly)</td>
+        <td>Firefox (Firefox aurora)</td>
+        <td>Firefox (Firefox beta)</td>
+        <th>(expected release date as YYYY-MM-DD)</th>
+        <td>Firefox (Firefox release)</td>
+      </tr>
+      (...other rows...)
+    </table>
+    (...more content...)
+    <h2><span id="Past_branch_dates">(TITLE)</span></h2>
+    (...anything other than a table...)
+    <table>
+      (header row)
+      <tr>
+        (..other td columns...)
         <th>(expected merge date as YYYY-MM-DD)</th>
         <td>Firefox (Firefox nightly)</td>
         <td>Firefox (Firefox aurora)</td>
@@ -41,11 +57,12 @@ Takes data from the RapidRelease page of the Mozilla Wiki. The page is expected 
       (...other rows...)
     </table>
     (...rest of document...)"""
-    # scrape for future release date tables
     response = json.loads(urllib2.urlopen("https://wiki.mozilla.org/api.php?action=parse&format=json&page=RapidRelease/Calendar").read())
     soup = BeautifulSoup(response["parse"]["text"]["*"])
-    table = soup.find(id="Future_branch_dates").find_parent("h2").find_next_sibling("table")
     result = {}
+    
+    # scrape for future release date tables
+    table = soup.find(id="Future_branch_dates").find_parent("h2").find_next_sibling("table")
     for i, row in enumerate(table.find_all("tr")):
         if i < 2: continue # skip the header row and the current release version
         fields = list(row.find_all("td"))
@@ -67,9 +84,34 @@ Takes data from the RapidRelease page of the Mozilla Wiki. The page is expected 
             nightly_date = datetime.strptime(nightly_date_string, "%Y-%m-%d").date()
             result[nightly_version] = nightly_date
         except ValueError: pass
+    
+    # scrape for past release date tables
+    table = soup.find(id="Past_branch_dates").find_parent("h2").find_next_sibling("table")
+    for i, row in enumerate(table.find_all("tr")):
+        if i == 0: continue # skip the header row
+        fields = list(row.find_all("td"))
+        if len(fields) != 4: continue # row with some blank entries
+        nightly_version = str(version_get_major(fields[-4].string.replace("Firefox ", ""))) + ".0a1"
+        aurora_version  = str(version_get_major(fields[-3].string.replace("Firefox ", ""))) + ".0a2"
+        beta_version    = str(version_get_major(fields[-2].string.replace("Firefox ", ""))) + ".0b1"
+        release_version = str(version_get_major(fields[-1].string.replace("Firefox ", ""))) + ".0"
+        
+        release_date_string = list(row.find_all("th"))[-1].string.strip(" \t\r\n*")
+        try:
+            release_date = datetime.strptime(release_date_string, "%Y-%m-%d").date()
+            result[aurora_version] = release_date
+            result[beta_version] = release_date
+            result[release_version] = release_date
+        except ValueError: pass
+        
+        nightly_date_string = list(row.find_all("th"))[0].string.strip(" \t\r\n*")
+        try:
+            nightly_date = datetime.strptime(nightly_date_string, "%Y-%m-%d").date()
+            result[nightly_version] = nightly_date
+        except ValueError: pass
     return result
 
-def email_histogram_subscribers(now, notifiable_histograms, dry_run = False):
+def email_histogram_subscribers(now, notifiable_histograms, expired_histograms, dry_run = False):
     # organize histograms into buckets indexed by email
     email_histogram_names = {GENERAL_TELEMETRY_ALERT: []}
     for name, entry in notifiable_histograms:
@@ -82,26 +124,31 @@ def email_histogram_subscribers(now, notifiable_histograms, dry_run = False):
 
     # send emails to users detailing the histograms that they are subscribed to that are expiring
     for email, expiring_histogram_names in email_histogram_names.items():
-        email_body = """\
-The following histograms will be expiring on {}, and should be removed from the codebase, or have its expiry date updated:
-
-{}
-
-This is an automated message sent by Cerberus. See https://github.com/mozilla/cerberus for details and source code.""".format(
-            now + EMAIL_TIME_BEFORE,
-            "\n".join("* {} expires in version {} ({}) - {}".format(
-                name, version_normalize_nightly(entry["expires_in_version"]),
-                "watched by {}".format(", ".join(email for email in entry["alert_emails"])) if "alert_emails" in entry else "no watchers",
-                entry["description"]
-            ) for name, entry in notifiable_histograms if name in expiring_histogram_names)
-        )
+        expiring_list = "\n".join("* {name} expires in version {version} ({watchers}) - {description}".format(
+            name=name, version=version_normalize_nightly(entry["expires_in_version"]),
+            watchers="watched by {}".format(", ".join(email for email in entry["alert_emails"])) if "alert_emails" in entry else "no watchers",
+            description=entry["description"]
+        ) for name, entry in notifiable_histograms if name in expiring_histogram_names)
+        if email != GENERAL_TELEMETRY_ALERT: # alert to a normal watcher
+            email_body = """\
+The following histograms will be expiring on {}, and should be removed from the codebase, or have their expiry versions updated:\n\n{}\n
+This is an automated message sent by Cerberus. See https://github.com/mozilla/cerberus for details and source code.""".format(now + EMAIL_TIME_BEFORE, expiring_list)
+        else: # alert to the general Telemetry alert mailing list
+            expired_list = "\n".join("* {name} expired in version {version} - {description}".format(
+                name=name, version=version_normalize_nightly(entry["expires_in_version"]), description=entry["description"]
+            ) for name, entry in expired_histograms)
+            email_body = """\
+The following histograms will be expiring on {}, and should be removed from the codebase, or have their expiry versions updated:\n\n{}\n
+The following histograms are expired as of {}:\n\n{}\n
+This is an automated message sent by Cerberus. See https://github.com/mozilla/cerberus for details and source code.""".format(now + EMAIL_TIME_BEFORE, expiring_list, now, expired_list)
         if dry_run:
             print("Email notification for {}:\n===============================================\n{}\n===============================================\n".format(email, email_body))
         else:
             print("Sending email notification to {} with body:\n\n{}\n".format(email, email_body))
             send_ses(FROM_ADDR, "Telemetry Histogram Expiry", email_body, email)
 
-def is_expiring(histogram_entry, now, release_dates):
+def is_expiring(histogram_entry, now, release_dates, include_past = False):
+    """Returns `True` if the histogram `histogram_entry` is expiring on the date `now`, `False` otherwise."""
     # check if the histogram expires or not
     expiry_version = histogram_entry.get("expires_in_version", "never").strip()
     if expiry_version in {"never", "default"}: return False
@@ -109,31 +156,39 @@ def is_expiring(histogram_entry, now, release_dates):
     # check if the expiration version has a known release date
     expiry_version = version_normalize_nightly(expiry_version) # normalize the version to the nearest nightly if not specified
     if expiry_version in release_dates:
-        return release_dates[expiry_version] == now + EMAIL_TIME_BEFORE
-    return False # version expires in an unknown future version
+        return release_dates[expiry_version] <= now if include_past else release_dates[expiry_version] == now
+    
+    if include_past: # search for the oldest version that is greater than the current version and assume that is the release date
+        sorted_versions = sorted(release_dates.keys(), cmp=version_compare)
+        for version in sorted_versions:
+            if version_compare(expiry_version, version) <= 0:
+                return release_dates[version] <= now
+    
+    return False # version expires in an unknown future or past version
 
-def get_expiring_histograms(now, release_dates, histograms):
+def get_expiring_histograms(now, release_dates, histograms, include_past = False):
+    """Returns a list of pairs containing histogram names and histogram entries that are expiring, sorted alphabetically by name."""
     return sorted([
-        (name, entry) for name, entry in histograms.items() if is_expiring(entry, now, release_dates)
+        (name, entry) for name, entry in histograms.items() if is_expiring(entry, now, release_dates, include_past=include_past)
     ], key=lambda h: h[0])
 
 def run_tests():
     release_dates1 = {
-      "38.0a1": datetime(2015, 6, 2),
-      "39.0a1": datetime(2015, 6, 30),
-      "40.0a1": datetime(2015, 8, 11),
-      "41.0a1": datetime(2015, 9, 22),
-      "42.0a1": datetime(2015, 11, 3),
-      "43.0a1": datetime(2015, 12, 15),
-      "44.0a1": datetime(2016, 1, 26),
-      "45.0a1": datetime(2016, 3, 8),
-      "46.0a1": datetime(2016, 4, 19),
-      "47.0a1": datetime(2016, 5, 31),
+      "38.0a1": date(2015, 6, 2),
+      "39.0a1": date(2015, 6, 30),
+      "40.0a1": date(2015, 8, 11),
+      "41.0a1": date(2015, 9, 22),
+      "42.0a1": date(2015, 11, 3),
+      "43.0a1": date(2015, 12, 15),
+      "44.0a1": date(2016, 1, 26),
+      "45.0a1": date(2016, 3, 8),
+      "46.0a1": date(2016, 4, 19),
+      "47.0a1": date(2016, 5, 31),
     }
     release_dates2 = {
-      "41.0a1": datetime(2015, 9, 22),
-      "42.0a1": datetime(2015, 11, 3),
-      "43.0a1": datetime(2015, 12, 15),
+      "41.0a1": date(2015, 9, 22),
+      "42.0a1": date(2015, 11, 3),
+      "43.0a1": date(2015, 12, 15),
     }
     histograms = {
         "a": {"expires_in_version": "40"},
@@ -144,15 +199,24 @@ def run_tests():
         "f": {"expires_in_version": "42"},
         "g": {"expires_in_version": "43"},
         "h": {"expires_in_version": "50a4"},
+        "i": {"expires_in_version": "38"},
     }
     
-    assert get_expiring_histograms(datetime(2015, 8, 3), release_dates1, histograms) == []
-    assert get_expiring_histograms(datetime(2015, 8, 4), release_dates1, histograms) == [("a", {"expires_in_version": "40"}), ("b", {"expires_in_version": "40"})]
-    assert get_expiring_histograms(datetime(2015, 8, 5), release_dates1, histograms) == []
-    assert get_expiring_histograms(datetime(2015, 9, 1), release_dates2, histograms) == []
-    assert get_expiring_histograms(datetime(2015, 10, 26), release_dates2, histograms) == []
-    assert get_expiring_histograms(datetime(2015, 10, 27), release_dates2, histograms) == [("f", {"expires_in_version": "42"})]
-    assert get_expiring_histograms(datetime(2015, 10, 28), release_dates2, histograms) == []
+    assert get_expiring_histograms(date(2015, 8, 3) + EMAIL_TIME_BEFORE, release_dates1, histograms) == []
+    assert get_expiring_histograms(date(2015, 8, 4) + EMAIL_TIME_BEFORE, release_dates1, histograms) == [("a", {"expires_in_version": "40"}), ("b", {"expires_in_version": "40"})]
+    assert get_expiring_histograms(date(2015, 8, 5) + EMAIL_TIME_BEFORE, release_dates1, histograms) == []
+    assert get_expiring_histograms(date(2015, 9, 1) + EMAIL_TIME_BEFORE, release_dates2, histograms) == []
+    assert get_expiring_histograms(date(2015, 10, 26) + EMAIL_TIME_BEFORE, release_dates2, histograms) == []
+    assert get_expiring_histograms(date(2015, 10, 27) + EMAIL_TIME_BEFORE, release_dates2, histograms) == [("f", {"expires_in_version": "42"})]
+    assert get_expiring_histograms(date(2015, 10, 28) + EMAIL_TIME_BEFORE, release_dates2, histograms) == []
+    
+    assert get_expiring_histograms(date(2015, 8, 3) + EMAIL_TIME_BEFORE, release_dates1, histograms, True) == [("i", {"expires_in_version": "38"})]
+    assert get_expiring_histograms(date(2015, 8, 4) + EMAIL_TIME_BEFORE, release_dates1, histograms, True) == [("a", {"expires_in_version": "40"}), ("b", {"expires_in_version": "40"}), ("i", {"expires_in_version": "38"})]
+    assert get_expiring_histograms(date(2015, 8, 5) + EMAIL_TIME_BEFORE, release_dates1, histograms, True) == [("a", {"expires_in_version": "40"}), ("b", {"expires_in_version": "40"}), ("i", {"expires_in_version": "38"})]
+    assert get_expiring_histograms(date(2015, 9, 1) + EMAIL_TIME_BEFORE, release_dates2, histograms, True) == []
+    assert get_expiring_histograms(date(2015, 10, 26) + EMAIL_TIME_BEFORE, release_dates2, histograms, True) == [("a", {"expires_in_version": "40"}), ("b", {"expires_in_version": "40"}), ("c", {"expires_in_version": "40.5"}), ("i", {"expires_in_version": "38"})]
+    assert get_expiring_histograms(date(2015, 10, 27) + EMAIL_TIME_BEFORE, release_dates2, histograms, True) == [("a", {"expires_in_version": "40"}), ("b", {"expires_in_version": "40"}), ("c", {"expires_in_version": "40.5"}), ("f", {"expires_in_version": "42"}), ("i", {"expires_in_version": "38"})]
+    assert get_expiring_histograms(date(2015, 10, 28) + EMAIL_TIME_BEFORE, release_dates2, histograms, True) == [("a", {"expires_in_version": "40"}), ("b", {"expires_in_version": "40"}), ("c", {"expires_in_version": "40.5"}), ("f", {"expires_in_version": "42"}), ("i", {"expires_in_version": "38"})]
 
     print "All tests passed!"
     sys.exit()
@@ -183,12 +247,13 @@ def main():
     
     # get a list of histograms that are expiring and net yet notified about, sorted alphabetically
     with open(HISTOGRAMS_FILE) as f: histograms = json.load(f)
-    release_dates = get_future_release_dates()
-    notifiable_histograms = get_expiring_histograms(now, release_dates, histograms)
+    release_dates = get_release_dates()
+    notifiable_histograms = get_expiring_histograms(now + EMAIL_TIME_BEFORE, release_dates, histograms)
+    expired_histograms = get_expiring_histograms(now, release_dates, histograms, include_past=True)
     if sys.argv[1] == "preview":
-        email_histogram_subscribers(now, notifiable_histograms, dry_run = True)
+        email_histogram_subscribers(now, notifiable_histograms, expired_histograms, dry_run = True)
     else: # send out emails
-        email_histogram_subscribers(now, notifiable_histograms)
+        email_histogram_subscribers(now, notifiable_histograms, expired_histograms)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
    $ python expiring.py preview 2015-08-03
    Email notification for dev-telemetry-alerts@lists.mozilla.org:
    ===============================================
    The following histograms will be expiring on 2015-08-10, and should be removed from the codebase, or have their expiry versions updated:

    * LOOP_SHARING_STATE_CHANGE_1 expires in version 43.0a1 (watched by firefox-dev@mozilla.org, mdeboer@mozilla.com) - Number of times the sharing feature has been enabled and disabled (0=WINDOW_ENABLED, 1=WINDOW_DISABLED, 2=BROWSER_ENABLED, 3=BROWSER_DISABLED)
    * LOOP_TWO_WAY_MEDIA_CONN_LENGTH_1 expires in version 43.0a1 (watched by firefox-dev@mozilla.org, dmose@mozilla.com) - Connection length for bi-directionally connected media (0=SHORTER_THAN_10S, 1=BETWEEN_10S_AND_30S, 2=BETWEEN_30S_AND_5M, 3=MORE_THAN_5M)

    The following histograms are expired as of 2015-08-03:

    * BLOCKLIST_SYNC_FILE_LOAD expired in version 35.0a1 - blocklist.xml has been loaded synchronously *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * BROWSERPROVIDER_XUL_IMPORT_HISTORY expired in version 40.0a1 - Number of history entries in the original XUL places database
    * BROWSERPROVIDER_XUL_IMPORT_TIME expired in version 40.0a1 - Time for the initial conversion of a XUL places database (ms)
    * CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSDISKCACHEBINDING_DESTRUCTOR expired in version 40.0a1 - Time spent waiting on the cache service lock (ms) on the main thread in NSDISKCACHEBINDING_DESTRUCTOR *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSDISKCACHEDEVICEDEACTIVATEENTRYEVENT_RUN expired in version 40.0a1 - Time spent waiting on the cache service lock (ms) on the main thread in NSDISKCACHEDEVICEDEACTIVATEENTRYEVENT_RUN *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSDISKCACHEMAP_REVALIDATION expired in version 40.0a1 - Time spent waiting on the cache service lock (ms) on the main thread in NSDISKCACHEMAP_REVALIDATION *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSDISKCACHESTREAMIO_CLOSEOUTPUTSTREAM expired in version 40.0a1 - Time spent waiting on the cache service lock (ms) on the main thread in NSDISKCACHESTREAMIO_CLOSEOUTPUTSTREAM *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSDISKCACHESTREAMIO_WRITE expired in version 40.0a1 - Time spent waiting on the cache service lock (ms) on the main thread in NSDISKCACHESTREAMIO_WRITE *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * CACHE_SERVICE_LOCK_WAIT_MAINTHREAD_NSEVICTDISKCACHEENTRIESEVENT_RUN expired in version 40.0a1 - Time spent waiting on the cache service lock (ms) on the main thread in NSEVICTDISKCACHEENTRIESEVENT_RUN *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * COOKIES_3RDPARTY_NUM_ATTEMPTS_ACCEPTED expired in version 40.0a1 - The total number of distinct attempts by third-party sites to place cookies which have been accepted.  Measures are normalized per 24h. *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * COOKIES_3RDPARTY_NUM_ATTEMPTS_BLOCKED expired in version 40.0a1 - The total number of distinct attempts by third-party sites to place cookies which have been rejected.  Measures are normalized per 24h. *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * COOKIES_3RDPARTY_NUM_SITES_ACCEPTED expired in version 40.0a1 - The number of distinct pairs (first-party site, third-party site attempting to set cookie) for which the third-party cookie has been accepted. Sites are considered identical if they have the same eTLD + 1. Measures are normalized per 24h. *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * COOKIES_3RDPARTY_NUM_SITES_BLOCKED expired in version 40.0a1 - The number of distinct pairs (first-party site, third-party site attempting to set cookie) for which the third-party cookie has been rejected. Sites are considered identical if they have the same eTLD + 1. Measures are normalized per 24h. *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * DATABASE_LOCKED_EXCEPTION expired in version 42.0a1 - Record database locks when opening one of Fennec's databases. The index corresponds to how many attempts, beginning with 0.
    * DATABASE_SUCCESSFUL_UNLOCK expired in version 42.0a1 - Record on which attempt we successfully unlocked a database. See DATABASE_LOCKED_EXCEPTION.
    * DISK_CACHE_CORRUPT_DETAILS expired in version 40.0a1 - Why the HTTP disk cache was corrupted at startup
    * DISK_CACHE_INVALIDATION_SUCCESS expired in version 40.0a1 - Stores 1 if writing '0' to the cache clean file succeeded, and 0 if it failed.
    * DISK_CACHE_REDUCTION_TRIAL expired in version 40.0a1 - Stores 1 if the cache would be clean with the disk cache corruption plan of Bug 105843
    * DISK_CACHE_REVALIDATION_SAFE expired in version 40.0a1 - Stores 1 if the cache clean file was revalidated, or 0 if a non empty doom list prevented revalidation
    * DISK_CACHE_REVALIDATION_SUCCESS expired in version 40.0a1 - Stores 1 if writing '1' to the cache clean file succeeded, and 0 if it failed.
    * DISK_CACHE_SMART_SIZE_USING_OLD_MAX expired in version 40.0a1 - Whether we are using the old default cache smart size
    * DOM_RANGE_DETACHED expired in version 40.0a1 - DOM: Ranges that are detached on destruction (bug 702948) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * DOM_TIMERS_FIRED_PER_NATIVE_TIMEOUT expired in version 40.0a1 - DOM: Timer handlers called per native timer expiration *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * DOM_TIMERS_RECENTLY_SET expired in version 40.0a1 - DOM: setTimeout/setInterval calls recently (last 30s or more) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * DOM_WINDOW_SHOWMODALDIALOG_USED expired in version 41.0a1 - Whether Window.showModalDialog was used in this session
    * EARLY_GLUESTARTUP_HARD_FAULTS expired in version 40.0a1 - Hard faults count before glue startup *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * EARLY_GLUESTARTUP_READ_OPS expired in version 40.0a1 - ProcessIoCounters.ReadOperationCount before glue startup *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * EARLY_GLUESTARTUP_READ_TRANSFER expired in version 40.0a1 - ProcessIoCounters.ReadTransferCount before glue startup (KB) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * FENNEC_FAVICONS_COUNT expired in version 40.0a1 - Number of favicons stored in the browser DB *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * FENNEC_READING_LIST_COUNT expired in version 40.0a1 - Number of reading list items stored in the browser DB *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * FENNEC_THUMBNAILS_COUNT expired in version 40.0a1 - Number of thumbnails stored in the browser DB *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * FENNEC_TILES_CACHE_HIT expired in version 40.0a1 - Cache hits on the tile-info metadata database *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * FX_GESTURE_TAKE_SNAPSHOT_OF_PAGE expired in version 40.0a1 - Firefox: Time taken to capture the page to a canvas, for reuse while swiping through history (ms).
    * FX_IDENTITY_POPUP_OPEN_MS expired in version 40.0a1 - Firefox: Time taken by the identity popup to open in milliseconds
    * FX_TAB_ANIM_ANY_FRAME_PAINT_MS expired in version 40.0a1 - Average paint duration during any tab open/close animation (excluding tabstrip scroll) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * FX_TAB_ANIM_CLOSE_MS expired in version 40.0a1 - Firefox: Time taken by the tab closing animation in milliseconds *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * FX_TAB_ANIM_OPEN_MS expired in version 40.0a1 - Firefox: Time taken by the tab opening animation in milliseconds *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * GLUESTARTUP_HARD_FAULTS expired in version 40.0a1 - Hard faults count after glue startup *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * GLUESTARTUP_READ_OPS expired in version 40.0a1 - ProcessIoCounters.ReadOperationCount after glue startup *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * GLUESTARTUP_READ_TRANSFER expired in version 40.0a1 - ProcessIoCounters.ReadTransferCount after glue startup (KB) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * HTML_BACKGROUND_REFLOW_MS_2 expired in version 40.0a1 - HTML reflows in background windows (ms)
    * IDLE_NOTIFY_BACK_LISTENERS expired in version 40.0a1 - Number of listeners notified that the user is back
    * IDLE_NOTIFY_BACK_MS expired in version 40.0a1 - Time spent checking for and notifying listeners that the user is back (ms)
    * IDLE_NOTIFY_IDLE_LISTENERS expired in version 40.0a1 - Number of listeners notified that the user is idle
    * LOCALDOMSTORAGE_CLEAR_BLOCKING_MS expired in version 40.0a1 - Time to block before we clear LocalStorage for all domains (ms)
    * LOCALDOMSTORAGE_GETALLKEYS_BLOCKING_MS expired in version 40.0a1 - Time to block before we return a list of all keys in domain's LocalStorage (ms)
    * LOCALDOMSTORAGE_GETKEY_BLOCKING_MS expired in version 40.0a1 - Time to block before we return a key name in domain's LocalStorage (ms)
    * LOCALDOMSTORAGE_GETLENGTH_BLOCKING_MS expired in version 40.0a1 - Time to block before we return number of keys in domain's LocalStorage (ms)
    * LOCALDOMSTORAGE_INIT_DATABASE_MS expired in version 40.0a1 - Time to open the localStorage database (ms)
    * LOCALDOMSTORAGE_KEY_SIZE_BYTES expired in version 40.0a1 - DOM storage: size of keys stored in localStorage
    * LOCALDOMSTORAGE_REMOVEKEY_BLOCKING_MS expired in version 40.0a1 - Time to block before we remove a single key from LocalStorage (ms)
    * LOCALDOMSTORAGE_SESSIONONLY_PRELOAD_BLOCKING_MS expired in version 40.0a1 - Time to fetch LocalStorage data before we can expose them as session only data (ms)
    * LOCALDOMSTORAGE_SETVALUE_BLOCKING_MS expired in version 40.0a1 - Time to block before we set a single key's value in LocalStorage (ms)
    * LOCALDOMSTORAGE_UNLOAD_BLOCKING_MS expired in version 40.0a1 - Time to fetch LocalStorage data before we can clean the cache (ms)
    * LOCALDOMSTORAGE_VALUE_SIZE_BYTES expired in version 40.0a1 - DOM storage: size of values stored in localStorage
    * MOZ_SQLITE_COOKIES_READ_B expired in version 40.0a1 - SQLite read() (bytes) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_COOKIES_READ_MAIN_THREAD_MS expired in version 40.0a1 - Time spent on SQLite read() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_COOKIES_READ_MS expired in version 40.0a1 - Time spent on SQLite read() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_COOKIES_WRITE_B expired in version 40.0a1 - SQLite write (bytes) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_COOKIES_WRITE_MAIN_THREAD_MS expired in version 40.0a1 - Time spent on SQLite write() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_COOKIES_WRITE_MS expired in version 40.0a1 - Time spent on SQLite write() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_OPEN_MAIN_THREAD_MS expired in version 40.0a1 - Time spent on SQLite open() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_OTHER_READ_MAIN_THREAD_MS expired in version 40.0a1 - Time spent on SQLite read() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_OTHER_READ_MS expired in version 40.0a1 - Time spent on SQLite read() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_OTHER_WRITE_MAIN_THREAD_MS expired in version 40.0a1 - Time spent on SQLite write() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_OTHER_WRITE_MS expired in version 40.0a1 - Time spent on SQLite write() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_PLACES_READ_B expired in version 40.0a1 - SQLite read() (bytes) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_PLACES_READ_MAIN_THREAD_MS expired in version 40.0a1 - Time spent on SQLite read() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_PLACES_READ_MS expired in version 40.0a1 - Time spent on SQLite read() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_PLACES_WRITE_B expired in version 40.0a1 - SQLite write (bytes) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_PLACES_WRITE_MAIN_THREAD_MS expired in version 40.0a1 - Time spent on SQLite write() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_TRUNCATE_MAIN_THREAD_MS expired in version 40.0a1 - Time spent on SQLite truncate() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_TRUNCATE_MS expired in version 40.0a1 - Time spent on SQLite truncate() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_WEBAPPS_READ_B expired in version 40.0a1 - SQLite read() (bytes) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_WEBAPPS_READ_MAIN_THREAD_MS expired in version 40.0a1 - Time spent on SQLite read() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_WEBAPPS_READ_MS expired in version 40.0a1 - Time spent on SQLite read() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_WEBAPPS_WRITE_B expired in version 40.0a1 - SQLite write (bytes) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_WEBAPPS_WRITE_MAIN_THREAD_MS expired in version 40.0a1 - Time spent on SQLite write() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_SQLITE_WEBAPPS_WRITE_MS expired in version 40.0a1 - Time spent on SQLite write() (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_STORAGE_ASYNC_REQUESTS_MS expired in version 40.0a1 - mozStorage async requests completion (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * MOZ_STORAGE_ASYNC_REQUESTS_SUCCESS expired in version 40.0a1 - mozStorage async requests success *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * NETWORK_CACHE_FS_TYPE expired in version 42.0a1 - Type of FS that the cache is stored on (0=NTFS (Win), 1=FAT32 (Win), 2=FAT (Win), 3=other FS (Win), 4=other OS)
    * NETWORK_CACHE_SIZE_FULL_FAT expired in version 42.0a1 - Size (in MB) of a cache that reached a file count limit
    * NETWORK_DISK_CACHE_REVALIDATION expired in version 40.0a1 - Total Time spent (ms) during disk cache revalidation
    * NETWORK_DISK_CACHE_STREAMIO_CLOSE expired in version 40.0a1 - Time spent in nsDiskCacheStreamIO::Close() on non-main thread (ms)
    * NETWORK_DISK_CACHE_STREAMIO_CLOSE_MAIN_THREAD expired in version 40.0a1 - Time spent in nsDiskCacheStreamIO::Close() on the main thread (ms)
    * NEWTAB_PAGE_SHOWN expired in version 35.0a1 - Number of times about:newtab was shown from opening a new tab or window. *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * NEWTAB_PAGE_SITE_CLICKED expired in version 35.0a1 - Track click count on about:newtab tiles per index (0-8). For non-default row or column configurations all clicks into the '9' bucket. *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * PANORAMA_GROUPS_COUNT expired in version 40.0a1 - Number of groups in Panorama *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * PANORAMA_INITIALIZATION_TIME_MS expired in version 40.0a1 - Time it takes to initialize Panorama (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * PANORAMA_MEDIAN_TABS_IN_GROUPS_COUNT expired in version 40.0a1 - Median of tabs in groups in Panorama
    * PANORAMA_STACKED_GROUPS_COUNT expired in version 40.0a1 - Number of stacked groups in Panorama *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * POPUP_NOTIFICATION_MAINACTION_TRIGGERED_MS expired in version 40.0a1 - The time (in milliseconds) after showing a PopupNotification that the mainAction was first triggered
    * READER_MODE_DOWNLOAD_MS expired in version 42.0a1 - Time (ms) to download a document to show in reader mode
    * READER_MODE_DOWNLOAD_RESULT expired in version 42.0a1 - The result of trying to download a document to show in reader view (0=Success, 1=Error XHR, 2=Error no document)
    * READER_MODE_PARSE_RESULT expired in version 42.0a1 - The result of trying to parse a document to show in reader view (0=Success, 1=Error too many elements, 2=Error in worker, 3=Error no article)
    * READER_MODE_SERIALIZE_DOM_MS expired in version 42.0a1 - Time (ms) to serialize a DOM to send to the reader worker
    * READER_MODE_WORKER_PARSE_MS expired in version 42.0a1 - Time (ms) for the reader worker to parse a document
    * SEARCH_SERVICE_BUILD_CACHE_MS expired in version 40.0a1 - Time (ms) it takes to build the cache of the search service
    * SESSIONDOMSTORAGE_KEY_SIZE_BYTES expired in version 40.0a1 - DOM storage: size of keys stored in sessionStorage
    * SESSIONDOMSTORAGE_VALUE_SIZE_BYTES expired in version 40.0a1 - DOM storage: size of values stored in sessionStorage
    * SQLITEBRIDGE_PROVIDER_FORMS_LOCKED expired in version 40.0a1 - The number of errors using the FormHistoryProvider due to a locked DB. *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * SQLITEBRIDGE_PROVIDER_HOME_LOCKED expired in version 40.0a1 - The number of errors using the HomeProvider due to a locked DB. *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * SQLITEBRIDGE_PROVIDER_PASSWORDS_LOCKED expired in version 40.0a1 - The number of errors using the PasswordsProvider due to a locked DB. *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * SSL_PERMANENT_CERT_ERROR_OVERRIDES expired in version 42.0a1 - How many permanent certificate overrides a user has stored.
    * TELEMETRY_TEST_EXPIRED expired in version 4.0a1 - a testing histogram; not meant to be touched
    * UDP_SOCKET_PARALLEL_CLOSE_COUNT expired in version 41.0a1 - Number of concurrent UDP socket closing threads
    * VIDEO_ADOBE_GMP_DISAPPEARED expired in version 42.0a1 - Whether or not the Adobe EME GMP was expected to be resident on disk but mysteriously isn't.
    * VIDEO_OPENH264_GMP_DISAPPEARED expired in version 42.0a1 - Whether or not the OpenH264 GMP was expected to be resident on disk but mysteriously isn't.
    * XUL_BACKGROUND_REFLOW_MS expired in version 40.0a1 - XUL reflows in background windows (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * XUL_FOREGROUND_REFLOW_MS expired in version 40.0a1 - XUL reflows in foreground windows (ms) *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***
    * XUL_INITIAL_FRAME_CONSTRUCTION expired in version 40.0a1 - initial xul frame construction *** No longer needed (bug 1156565). Delete histogram and accumulation code! ***

    This is an automated message sent by Cerberus. See https://github.com/mozilla/cerberus for details and source code.
    ===============================================

    Email notification for dmose@mozilla.com:
    ===============================================
    The following histograms will be expiring on 2015-08-10, and should be removed from the codebase, or have their expiry versions updated:

    * LOOP_TWO_WAY_MEDIA_CONN_LENGTH_1 expires in version 43.0a1 (watched by firefox-dev@mozilla.org, dmose@mozilla.com) - Connection length for bi-directionally connected media (0=SHORTER_THAN_10S, 1=BETWEEN_10S_AND_30S, 2=BETWEEN_30S_AND_5M, 3=MORE_THAN_5M)

    This is an automated message sent by Cerberus. See https://github.com/mozilla/cerberus for details and source code.
    ===============================================

    Email notification for mdeboer@mozilla.com:
    ===============================================
    The following histograms will be expiring on 2015-08-10, and should be removed from the codebase, or have their expiry versions updated:

    * LOOP_SHARING_STATE_CHANGE_1 expires in version 43.0a1 (watched by firefox-dev@mozilla.org, mdeboer@mozilla.com) - Number of times the sharing feature has been enabled and disabled (0=WINDOW_ENABLED, 1=WINDOW_DISABLED, 2=BROWSER_ENABLED, 3=BROWSER_DISABLED)

    This is an automated message sent by Cerberus. See https://github.com/mozilla/cerberus for details and source code.
    ===============================================

    Email notification for firefox-dev@mozilla.org:
    ===============================================
    The following histograms will be expiring on 2015-08-10, and should be removed from the codebase, or have their expiry versions updated:

    * LOOP_SHARING_STATE_CHANGE_1 expires in version 43.0a1 (watched by firefox-dev@mozilla.org, mdeboer@mozilla.com) - Number of times the sharing feature has been enabled and disabled (0=WINDOW_ENABLED, 1=WINDOW_DISABLED, 2=BROWSER_ENABLED, 3=BROWSER_DISABLED)
    * LOOP_TWO_WAY_MEDIA_CONN_LENGTH_1 expires in version 43.0a1 (watched by firefox-dev@mozilla.org, dmose@mozilla.com) - Connection length for bi-directionally connected media (0=SHORTER_THAN_10S, 1=BETWEEN_10S_AND_30S, 2=BETWEEN_30S_AND_5M, 3=MORE_THAN_5M)

    This is an automated message sent by Cerberus. See https://github.com/mozilla/cerberus for details and source code.
    ===============================================

