### PR TITLE
Fix histograms file path

### DIFF
--- a/alert/expiring.py
+++ b/alert/expiring.py
@@ -14,7 +14,7 @@ from mozilla_versions import version_compare, version_get_major, version_normali
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
-HISTOGRAMS_FILE         = os.path.join(SCRIPT_DIR, "Histograms.json") # histogram definitions file
+HISTOGRAMS_FILE         = os.path.join(SCRIPT_DIR, "..", "Histograms.json") # histogram definitions file
 EMAIL_TIME_BEFORE       = timedelta(weeks=1) # release future date offset
 FROM_ADDR               = "telemetry-alert@mozilla.com" # email address to send alerts from
 GENERAL_TELEMETRY_ALERT = "dev-telemetry-alerts@lists.mozilla.org" # email address that will receive all notifications

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,7 @@
 sudo apt-get -qq update
 sudo DEBIAN_FRONTEND=noninteractive apt-get -qq -y install python-simplejson python-boto nodejs npm python-numpy python-opencv python-matplotlib
 
-pushd .
+pushd . > /dev/null
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 git pull
@@ -16,4 +16,4 @@ python alert/alert.py &&
 python alert/post.py &&
 python alert/expiring.py email
 
-popd
+popd > /dev/null


### PR DESCRIPTION
Currently Histograms.json is located in the Cerberus project root. This PR accounts for this in the relative path handling.