### PR TITLE
Significantly reduce memory usage

### DIFF
--- a/exporter/export.js
+++ b/exporter/export.js
@@ -95,14 +95,16 @@ function handle_one() {
   return Promise.all(promises).then(function() {
     // Write file async
     return new Promise(function(accept, reject) {
-      fs.writeFile(
-        'histograms/' + measure + '.json',
-        JSON.stringify(result, null, 2),
-        function(err) {
-          if (err) return reject(err);
-          accept();
-        }
-      )
+      if (result.length > 0) {
+        fs.writeFile(
+          'histograms/' + measure + '.json',
+          JSON.stringify(result, null, 2),
+          function(err) {
+            if (err) return reject(err);
+            accept();
+          }
+        );
+      }
     }).then(function() {
       handle_one();
     });


### PR DESCRIPTION
* Avoid concat (which copies the entire source array)
* Avoid storing tons of data in Promise.all() (which keeps a copy of all of it until the end, when it is processed in bulk) - process it as it is received.
* Don't do the keys for keyed histograms, just like in the v2 pipeline exporter.
* Cerberus is currently swapping heavily on the AWS instance and very close to the memory limit.
* These changes allow the exporter to run without swapping at all - it runs at ~80mb on a 64-bit system, where before it would go to ~800mb.