### PR TITLE
Ignore development and working files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 node_modules/
+*.pyc
+*.pyo
+dashboard/regressions.json
+Histograms.json


### PR DESCRIPTION
These files are used in testing, development, and production, but shouldn't be in the repo.