### PR TITLE
Link to v4 histogram dashboard in regression alerts.

### DIFF
--- a/alert/post.py
+++ b/alert/post.py
@@ -34,6 +34,6 @@ with open('dashboard/regressions.json') as f:
                            'x_label': regression['description'],
                            'y_label': "Normalized Frequency Count",
                            'title': histogram_name,
-                           'link': "http://telemetry.mozilla.org/#filter=nightly/nn/" + histogram_name,
+                           'link': "http://telemetry.mozilla.org/new-pipeline/dist.html#!measure={histogram_name}&product=Firefox&start_date={date}&end_date={date}&table=0&use_submission_date=0".format(date=date, histogram_name=histogram_name),
                            'type': 'graph'}
                 poster.post_alert(detector, metric, payload, ",".join(regression['alert_emails']), date)


### PR DESCRIPTION
Depends on https://github.com/mozilla/telemetry-dashboard/pull/102 for the date ranges and measure selection to work correctly.

Link to v4 histogram dashboard, with the correct day and measure selected for the regression, instead of the advanced dashboard.