### PR TITLE
Validate histograms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 dashboard/regressions.json
 Histograms.json
 histograms/
+.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "dev" do |dev|
     dev.ssh.insert_key = false
-    dev.vm.box = "ubuntu/vivid64"
+    dev.vm.box = "ubuntu/wily64"
     dev.vm.provision "ansible" do |ansible|
       ansible.host_key_checking = false
       ansible.playbook = "ansible/dev.yml"

--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,8 @@
 pushd . > /dev/null
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+ln /dev/null /dev/raw1394 # this is needed to fix the `libdc1394 error: Failed to initialize libdc1394` error from OpenCV, in alert/alert.py
+
 rm -rf ./histograms Histograms.json &&
 wget https://raw.githubusercontent.com/mozilla/gecko-dev/master/toolkit/components/telemetry/Histograms.json -O Histograms.json && # update histogram metadata
 nodejs exporter/export.js && # export histogram evolutions using Telemetry.js to JSON, under `histograms/*.JSON`


### PR DESCRIPTION
This fixes the `libdc1394 error: Failed to initialize libdc1394` error from OpenCV (the `ln /dev/null /dev/raw1394` must be run on every reboot, so I've put it in run.sh).

This also mitigates the damage from histograms changing size. See https://bugzilla.mozilla.org/show_bug.cgi?id=1261530 for details. With these checks in place, we can identify this sort of issue more easily in the future.

Also, update the Vagrant config, which was broken due to using the vivid64, which is no longer available.