### PR TITLE
Bug 1306623, Bug 1330988 - Scalar Regression and Expiration Support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "dev" do |dev|
     dev.ssh.insert_key = false
-    dev.vm.box = "ubuntu/wily64"
+    dev.vm.box = "gigerdo/ubuntu-wily"
     dev.vm.provision "ansible" do |ansible|
       ansible.host_key_checking = false
       ansible.playbook = "ansible/dev.yml"

--- a/alert/alert.py
+++ b/alert/alert.py
@@ -176,13 +176,17 @@ def plot(file_name, histogram_name, buckets, raw_histograms):
     pylab.close(fig)
 
 def main():
-    global histograms
     regressions = []
 
     # This is the same Histograms.json as the one in mozilla-central
     # It should always be the latest possible version when running
     with open("Histograms.json") as f:
         histograms = json.load(f)
+
+    with open("Scalars.json") as f:
+        scalars = json.load(f)
+
+    probes = dict(histograms.items() + scalars.items())
 
     #logging.basicConfig(level=logging.DEBUG)
     #process_file('./histograms/FX_TAB_ANIM_ANY_FRAME_INTERVAL_MS.json', regressions)
@@ -222,8 +226,10 @@ def main():
             name = histogram
             if histogram.startswith("STARTUP"):
                 name = histogram[8:]
-            descriptor["description"] = histograms.get(name, {}).get("description", "")
-            descriptor["alert_emails"] = histograms.get(name, {}).get("alert_emails", "")
+
+            probe_def = probes.get(name, {})
+            descriptor["description"] = probe_def.get("description", "")
+            descriptor["alert_emails"] = probe_def.get("alert_emails", probe_def.get("notification_emails", ""))
 
     # Store regressions found
     with open(REGRESSION_FILENAME, 'w') as f:

--- a/alert/post.py
+++ b/alert/post.py
@@ -14,9 +14,15 @@ except IOError:
 # Update histogram definitions on the server and update subscriptions
 with open('Histograms.json') as f:
     histograms = json.load(f)
-    for name, description in histograms.iteritems():
-        metric = poster.Metric(name, description['description'], detector)
-        metric.realize()
+
+with open("Scalars.json") as f:
+    scalars = json.load(f)
+
+probes = dict(histograms.items() + scalars.items())
+
+for name, description in probes.iteritems():
+    metric = poster.Metric(name, description['description'], detector)
+    metric.realize()
 
 # Post detected alerts
 with open('dashboard/regressions.json') as f:

--- a/exporter/package.json
+++ b/exporter/package.json
@@ -9,6 +9,7 @@
     "lodash":                           "2.4.1",
     "debug":                            "0.7.4",
     "mkdirp":                           "0.5.0",
-    "telemetry-next-node":              ">=1.1.0"
+    "telemetry-next-node":              ">=1.1.0",
+    "js-yaml":                          "3.8.2"
   }
 }

--- a/run.sh
+++ b/run.sh
@@ -7,8 +7,11 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 ln /dev/null /dev/raw1394 # this is needed to fix the `libdc1394 error: Failed to initialize libdc1394` error from OpenCV, in alert/alert.py
 
-rm -rf ./histograms Histograms.json &&
+rm -rf ./histograms Histograms.json Scalars.yaml &&
+
 wget https://raw.githubusercontent.com/mozilla/gecko-dev/master/toolkit/components/telemetry/Histograms.json -O Histograms.json && # update histogram metadata
+wget https://hg.mozilla.org/mozilla-central/raw-file/tip/toolkit/components/telemetry/Scalars.yaml -O Scalars.yaml && # update scalars metadata
+
 nodejs exporter/export.js && # export histogram evolutions using Telemetry.js to JSON, under `histograms/*.JSON`
 python alert/alert.py && # perform regression detection and output all found regressions to `dashboard/regressions.json`
 python alert/post.py && # post all the found regressions above to Medusa, the Telemetry alert system

--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,7 @@ ln /dev/null /dev/raw1394 # this is needed to fix the `libdc1394 error: Failed t
 
 rm -rf ./histograms Histograms.json Scalars.yaml &&
 
-wget https://raw.githubusercontent.com/mozilla/gecko-dev/master/toolkit/components/telemetry/Histograms.json -O Histograms.json && # update histogram metadata
+wget https://hg.mozilla.org/mozilla-central/raw-file/tip/toolkit/components/telemetry/Histograms.json -O Histograms.json && # update histogram metadata
 wget https://hg.mozilla.org/mozilla-central/raw-file/tip/toolkit/components/telemetry/Scalars.yaml -O Scalars.yaml && # update scalars metadata
 
 nodejs exporter/export.js && # export histogram evolutions using Telemetry.js to JSON, under `histograms/*.JSON`


### PR DESCRIPTION
This is pretty straightforward. I tested this on a local Medusa. Some scalar alerts actually showed! All scalars were available in the dropdown, as expected (though I'm not sure anyone uses that anyways).

Note the ubuntu/wily64 machine is not longer available on hashicorp.

@chutten r?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/cerberus/28)
<!-- Reviewable:end -->
